### PR TITLE
Fix cronjob and config bugs

### DIFF
--- a/hooks/hooks.py
+++ b/hooks/hooks.py
@@ -160,10 +160,12 @@ def config_changed():
     config = hookenv.config()
 
     if config.changed('frequency'):
-        hookenv.log("'frequency' changed, moving cron job to "
-                    "/etc/cron.{}".format(config['frequency']))
+        hookenv.log("'frequency' changed, removing cron job")
         uninstall_cron_script()
-        install_cron_script()
+        if config['run']:
+            hookenv.log("moving cron job to "
+                        "/etc/cron.{}".format(config['frequency']))
+            install_cron_script()
 
     if config.changed('run'):
         hookenv.log("'run' changed, removing existing cron jobs")


### PR DESCRIPTION
Fixes the following bugs:
- Main cron job had invalid name that caused it to be ignored silently by run-parts.
- hookenv.config was not being saved, so 'run' was always considered changed, and thus fastpoll job was always re-added, even if only 'frequency' was changed
- changing 'frequency' alone should not re-install the poll job
- changing 'frequency' while 'run' is false should not install the job.
