### PR TITLE
add interface for subordinate charm to provide image modification scripts

### DIFF
--- a/hooks/image-modifier-relation-changed
+++ b/hooks/image-modifier-relation-changed
@@ -1,0 +1,1 @@
+hooks.py

--- a/hooks/image-modifier-relation-joined
+++ b/hooks/image-modifier-relation-joined
@@ -1,0 +1,1 @@
+hooks.py

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -10,6 +10,9 @@ subordinate: false
 provides:
   simplestreams-image-service:
     interface: glance-simplestreams-sync
+  image-modifier:
+    scope: container
+    interface: script-provider
 requires:
   identity-service:
     interface: keystone

--- a/scripts/glance-simplestreams-sync.py
+++ b/scripts/glance-simplestreams-sync.py
@@ -142,6 +142,7 @@ def do_sync(charm_conf):
             store = None
 
         config = {'max_items': mirror_info['max'],
+                  'modify_hook': charm_conf['modify_hook_scripts'],
                   'keep_items': False,
                   'content_id': 'auto.sync',
                   'cloud_name': charm_conf['cloud_name'],

--- a/templates/mirrors.yaml
+++ b/templates/mirrors.yaml
@@ -1,4 +1,5 @@
 mirror_list: {{ mirror_list }}
+modify_hook_scripts: {{ modify_hook_scripts }}
 use_swift: {{ use_swift }}
 region: {{ region }}
 cloud_name: {{ cloud_name }}


### PR DESCRIPTION
From Paul Collins via LP:
https://code.launchpad.net/~pjdc/glance-simplestreams-sync-charm/image-modifier-hook/+merge/226242

Minor changes in MirrorsConfigServiceContext.**call** for readability and to fix an undefined ref in the handling of the keyerror exception.
