### PR TITLE
Retry connecting to rabbitmq at each message

### DIFF
--- a/scripts/glance-simplestreams-sync.py
+++ b/scripts/glance-simplestreams-sync.py
@@ -358,7 +358,7 @@ def cleanup():
             raise e
 
 
-if __name__ == "__main__":
+def main():
 
     log.info("glance-simplestreams-sync started.")
 
@@ -435,3 +435,7 @@ if __name__ == "__main__":
         os.unlink(CRON_POLL_FILENAME)
         log.info("Initial sync attempt done. every-minute cronjob removed.")
     log.info("sync done.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
If no connection exists, retry connecting to rabbit for each message sent.
Handles cases where rabbit is late to start, so we still deliver as many messages as possible.

Also adds a main() to avoid stupid globals() leakage.
