### PR TITLE
Store proxy environment variables in conf file

### DIFF
--- a/hooks/hooks.py
+++ b/hooks/hooks.py
@@ -99,13 +99,25 @@ class MirrorsConfigServiceContext(OSContextGenerator):
                     cloud_name=config['cloud_name'])
 
 
+class JujuProxyContext(OSContextGenerator):
+    """Context for http(s)-proxy and no-proxy juju environment settings"""
+
+    def __call__(self):
+        d = {}
+        for v in ['http_proxy', 'https_proxy', 'no_proxy']:
+            if v in os.environ:
+                d[v] = os.environ[v]
+        return d
+
+
 release = get_os_codename_package('glance-common', fatal=False) or 'icehouse'
 configs = OSConfigRenderer(templates_dir='templates/',
                            openstack_release=release)
 
 configs.register(MIRRORS_CONF_FILE_NAME, [MirrorsConfigServiceContext()])
 configs.register(ID_CONF_FILE_NAME, [IdentityServiceContext(),
-                                     AMQPContext()])
+                                     AMQPContext(),
+                                     JujuProxyContext()])
 
 
 def install_cron_script():

--- a/hooks/hooks.py
+++ b/hooks/hooks.py
@@ -213,6 +213,7 @@ def config_changed():
     hookenv.log('begin config-changed hook.')
 
     configs.write(MIRRORS_CONF_FILE_NAME)
+    configs.write(ID_CONF_FILE_NAME)
 
     config = hookenv.config()
 

--- a/scripts/glance-simplestreams-sync.py
+++ b/scripts/glance-simplestreams-sync.py
@@ -124,20 +124,6 @@ def policy(content, path):
         return content
 
 
-def set_juju_env():
-    proxy_filename = os.path.expanduser("~/.juju-proxy")
-    if not os.path.exists(proxy_filename):
-        return
-
-    with open(proxy_filename, 'r') as f:
-        lines = [l.strip() for l in f.readlines()]
-        for line in lines:
-            # lines are 'export var=val'.
-            export_ignored, env = line.split(' ', 1)
-            k, v = env.split('=', 1)
-            os.environ[k] = v
-
-
 def read_conf(filename):
     with open(filename) as f:
         confobj = yaml.load(f)
@@ -163,6 +149,14 @@ def get_conf():
         sys.exit(1)
 
     return id_conf, charm_conf
+
+
+def set_proxy_env(id_conf):
+    for env in ['http_proxy', 'https_proxy', 'no_proxy']:
+        if env not in id_conf:
+            continue
+        os.environ[env] = id_conf[env]
+        os.environ[env.upper()] = id_conf[env]
 
 
 def set_openstack_env(id_conf, charm_conf):
@@ -391,9 +385,9 @@ def main():
 
     lockfile.write(str(os.getpid()))
 
-    set_juju_env()
-
     id_conf, charm_conf = get_conf()
+
+    set_proxy_env(id_conf)
 
     set_openstack_env(id_conf, charm_conf)
 

--- a/templates/identity.yaml
+++ b/templates/identity.yaml
@@ -30,3 +30,15 @@ kombu_ssl_ca_certs: {{ rabbit_ssl_ca }}
 {% endif -%}
 {% endif -%}
 {% endif -%}
+
+{% if http_proxy -%}
+http_proxy: {{ http_proxy }}
+{% endif -%}
+
+{% if https_proxy -%}
+https_proxy: {{ https_proxy }}
+{% endif -%}
+
+{% if no_proxy -%}
+no_proxy: {{ no_proxy }}
+{% endif -%}


### PR DESCRIPTION
To avoid depending on parsing undocumented shell files using Python and to fix bugs in where the user running the cron job's home dir is, this grabs the proxy info from the hook environment, where juju guarantees it will exist, then just saves it into the config file the cron job already knows how to read.

This has been tested behind a corporate proxy and worked (and tested with a fake proxy locally, and broke as expected.)